### PR TITLE
Fixes to make the app work on API 27

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.twolinessoftware.android"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     compile 'com.vividsolutions:jts:1.13'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.twolinessoftware.android"
-      android:versionCode="1"
-      android:versionName="1.0">
+    package="com.twolinessoftware.android"
+    android:versionCode="1"
+    android:versionName="1.0">
 
-    <application android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:debuggable="true">
+    <application
+        android:name=".MainApplication"
+        android:debuggable="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name">
 
-        <activity android:name=".MainActivity"
-                  android:label="@string/app_name">
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-    <service android:name="PlaybackService"></service>
-    
-    <uses-library android:name="android.test.runner" />
-</application>
+        <service android:name="PlaybackService"></service>
 
-<uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"></uses-permission>
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
-<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"></uses-permission>
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"></uses-permission>
-<uses-permission android:name="android.permission.SET_DEBUG_APP"></uses-permission>
+        <uses-library android:name="android.test.runner" />
+    </application>
+
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"></uses-permission>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"></uses-permission>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"></uses-permission>
+    <uses-permission android:name="android.permission.SET_DEBUG_APP"></uses-permission>
 </manifest> 

--- a/android/app/src/main/java/com/twolinessoftware/android/MainActivity.java
+++ b/android/app/src/main/java/com/twolinessoftware/android/MainActivity.java
@@ -78,16 +78,6 @@ public class MainActivity extends Activity implements GpsPlaybackListener {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.main);
 
-		// test that mock locations are allowed so a more descriptive error
-		// message can be logged
-		if (Settings.Secure.getInt(getContentResolver(),
-				Settings.Secure.ALLOW_MOCK_LOCATION, 0) == 0) {
-			Toast.makeText(this, "MockLocations needs to be enabled",
-					Toast.LENGTH_SHORT).show();
-			finish();
-
-		}
-
 		mEditText = (EditText) findViewById(R.id.file_path);
 
 		TextView mLabelEditText = (TextView) findViewById(R.id.label_edit_text_delay);
@@ -125,7 +115,7 @@ public class MainActivity extends Activity implements GpsPlaybackListener {
 		} catch (Exception ie) {
 		}
 
-		super.onPause();
+		super.onStop();
 
 	}
 

--- a/android/app/src/main/java/com/twolinessoftware/android/MainApplication.java
+++ b/android/app/src/main/java/com/twolinessoftware/android/MainApplication.java
@@ -1,0 +1,27 @@
+package com.twolinessoftware.android;
+
+import android.app.Application;
+import android.os.StrictMode;
+
+
+public class MainApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        /*
+        Never
+        Never ever
+        Never ever ever
+        Never ever ever EVER EVERERER do this in production code.
+
+        This is to get around android.os.FileUriExposedException in>=API24
+        The correct solution is to use a content:// URI with a FileProvider.
+
+         However since this app is only used for test purposes I'm using this work-around
+        */
+        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
+        StrictMode.setVmPolicy(builder.build());
+    }
+}

--- a/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.java
+++ b/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.java
@@ -26,6 +26,7 @@ import android.location.LocationManager;
 import android.os.AsyncTask;
 import android.os.IBinder;
 import android.os.RemoteException;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import com.twolinessoftware.android.framework.service.comms.gpx.GpxSaxParser;
@@ -46,6 +47,8 @@ import java.util.Date;
 public class PlaybackService extends Service implements GpxSaxParserListener {
 
     private NotificationManager mNM;
+
+    private static final String NOTIFICATION_CHANNEL_ID_DEFAULT = "default";
 
     private static final String LOG = PlaybackService.class.getSimpleName();
 
@@ -238,16 +241,17 @@ public class PlaybackService extends Service implements GpxSaxParserListener {
         // In this sample, we'll use the same text for the ticker and the expanded notification
         CharSequence text = "GPX Playback Running";
 
-        // Set the icon, scrolling text and timestamp
-        Notification notification = new Notification(R.drawable.ic_playback_running, text,
-                System.currentTimeMillis());
-
         // The PendingIntent to launch our activity if the user selects this notification
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0,
                 new Intent(this, MainActivity.class), 0);
 
-        // Set the info for the views that show in the notification panel.
-        notification.setLatestEventInfo(this, "GPX Playback Manager", text, contentIntent);
+        final Notification notification = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID_DEFAULT)
+                .setSmallIcon(R.drawable.ic_playback_running)
+                .setContentText(text)
+                .setWhen(System.currentTimeMillis())
+                .setContentIntent(contentIntent)
+                .setContentTitle("GPX Playback Manager")
+                .build();
 
         // Send the notification.
         mNM.notify(NOTIFICATION, notification);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 26 17:56:45 GMT 2015
+#Wed Apr 18 11:37:38 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Updated to work with API 27.

**WARNING:** There is some pretty nasty code in here which I would strongly recommend against using in a production app. Point 1 below is particularly offensive. I was comfortable with this workaround since I'm only using this app for testing.

1. Work around the `file://` URI ban in API 24 and above  by disabling that behavior using `StrictMode.VmPolicy` - ***particularly hideous***
2. Replace no longer available Notification APIs with `NotificationCompat.Builder` 
3. Recent versions of Gradle and AGP
