### PR TITLE
Fix reading timestamp values if delay is 0 or empty

### DIFF
--- a/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.java
+++ b/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.java
@@ -151,6 +151,9 @@ public class PlaybackService extends Service implements GpxSaxParserListener {
             long delayTimeOnReplay = Long.valueOf(timeFromIntent);
             queue.start(delayTimeOnReplay);
         }
+        else {
+            queue.start(0);
+        }
 
         // We want this service to continue running until it is explicitly
         // stopped, so return sticky.

--- a/android/app/src/main/java/com/twolinessoftware/android/SendLocationWorkerQueue.java
+++ b/android/app/src/main/java/com/twolinessoftware/android/SendLocationWorkerQueue.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 2linessoftware.com
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -48,8 +48,8 @@ public class SendLocationWorkerQueue {
 
     public synchronized void stop() {
         /*
-		 * synchronized(lock){ lock.notify(); }
-		 */
+         * synchronized(lock){ lock.notify(); }
+         */
         running = false;
     }
 
@@ -85,10 +85,19 @@ public class SendLocationWorkerQueue {
                 if (queue.size() > 0) {
 
                     SendLocationWorker worker = queue.pop();
+                    long delay = TIME_BETWEEN_SENDS;
+                    if (TIME_BETWEEN_SENDS == 0) {
+                        long delayFromNow = worker.getSendTime() - System.currentTimeMillis();
+                        if (delayFromNow > 0) {
+                            delay = delayFromNow;
+                        }
+                    }
 
                     synchronized (lock) {
                         try {
-                            lock.wait(TIME_BETWEEN_SENDS);
+                            if (delay > 0) {
+                                lock.wait(delay);
+                            }
 
                             Logger.i("SendLocationWorkerQueue.running - TIME_BETWEEN_SENDS : " + TIME_BETWEEN_SENDS, " - sent at time : " + System.currentTimeMillis());
                         } catch (InterruptedException e) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 18 11:37:38 CEST 2018
+#Fri Oct 30 11:54:28 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
This change will ensure that messages will be replayed just as the timestamp in the GPX provider specifies.

In addition, update Gradle.